### PR TITLE
Update to align with Mulesoft checklist items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,16 @@
 
     <parent>
         <groupId>org.mule.extensions</groupId>
-        <artifactId>mule-core-modules-parent</artifactId>
-        <version>1.1.9</version>
-        <relativePath></relativePath>
+        <artifactId>mule-modules-parent</artifactId>
+        <version>1.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.teradata.mulesoft</groupId>
-    <artifactId>teradata-connector</artifactId>
+    <artifactId>mule4-teradata-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>0.0.5</version>
-    <name>Teradata Connector</name>
+    <version>1.0.0</version>
+    <name>Teradata Connector - Mule 4</name>
     <description>An extension that provides functionality for connecting any Mule project to Teradata Vantage</description>
 
     <properties>
@@ -42,8 +41,8 @@
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
-        <munit.extensions.maven.plugin.version>1.1.3</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.11</munit.version>
+        <munit.extensions.maven.plugin.version>1.1.2</munit.extensions.maven.plugin.version>
+        <munit.version>2.2.4</munit.version>
 
         <mtf-tools.version>1.1.2</mtf-tools.version>
         <skipTita>false</skipTita>
@@ -99,6 +98,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-junit4</artifactId>
+            <version>2.19.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -172,33 +177,38 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>com.mulesoft.munit</groupId>
+                <artifactId>munit-extensions-maven-plugin</artifactId>
+                <version>${munit.extensions.maven.plugin.version}</version>
                 <executions>
                     <execution>
+                        <phase>integration-test</phase>
                         <goals>
-                            <!-- Needed artifact for testing purposes on mule-ee/tests/xa-tx-->
-                            <goal>test-jar</goal>
+                            <goal>test</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-help-plugin</artifactId>
-                <version>${maven.help.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>process-test-resources</phase>
-                        <id>copy-settings</id>
-                        <goals>
-                            <goal>effective-settings</goal>
-                        </goals>
-                        <configuration>
-                            <output>${settingsFile}</output>
-                            <showPasswords>true</showPasswords>
-                        </configuration>
-                    </execution>
-                </executions>
+                <dependencies>
+                    <!-- MUnit Dependencies -->
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-runner</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>munit-tools</artifactId>
+                        <version>${munit.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.mulesoft.munit</groupId>
+                        <artifactId>mtf-tools</artifactId>
+                        <version>${mtf-tools.version}</version>
+                        <classifier>mule-plugin</classifier>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -256,6 +266,24 @@
             <id>mule</id>
             <name>Mule Repository</name>
             <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </repository>
+        <repository>
+            <id>mulesoft-releases</id>
+            <name>MuleSoft Repository</name>
+            <url>http://repository.mulesoft.org/releases/</url>
+            <layout>default</layout>
+        </repository>
+        <repository>
+            <id>mulesoft-snapshots</id>
+            <name>MuleSoft Snapshot Repository</name>
+            <url>http://repository.mulesoft.org/snapshots/</url>
+            <layout>default</layout>
+        </repository>
+        <repository>
+            <id>mulesoft-public</id>
+            <name>MuleSoft Public Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+            <layout>default</layout>
         </repository>
     </repositories>
 

--- a/src/main/java/org/mule/extension/db/internal/DbConnector.java
+++ b/src/main/java/org/mule/extension/db/internal/DbConnector.java
@@ -6,6 +6,8 @@
  */
 package org.mule.extension.db.internal;
 
+import static org.mule.runtime.api.meta.Category.CERTIFIED;
+
 import org.mule.db.commons.AbstractDbConnector;
 import org.mule.db.commons.api.exception.connection.ConnectionCreationException;
 import org.mule.db.commons.api.exception.connection.DbError;
@@ -35,7 +37,7 @@ import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
  *
  * @since 1.0
  */
-@Extension(name = "Teradata")
+@Extension(name = "Teradata", category = CERTIFIED)
 @Operations({DbBulkOperations.class, DbDdlOperations.class, DbDmlOperations.class})
 @Sources(RowListener.class)
 @ConnectionProviders({TeradataConnectionProvider.class})


### PR DESCRIPTION
MuleSoft checklists updated:
1. Changed <artifactId> to mule4-teradata-connector
2. Changed <version> to 1.0.0 (it is the 1st version)
3. Added “ - Mule 4” at the end of <name> tag
4. Added category = Category.CERTIFIED in @Extension in connector class
5. Update Parent POM: org.mule.extensions:mule-core-modules-parent => org.mule.extensions:mule-modules-paren:1.3.2.
6. Removed plugins that are not accepted by the CI system:
maven-jar-plugin
org.apache.maven.plugins:maven-help-plugin

Unresolved item:
7. terajdbc4 dependency is not available and it is not specified as @ExternalLib

