### PR TITLE
Java 17 support extension in the Teradata MuleSoft Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
         <mule.maven.plugin.version>3.8.1</mule.maven.plugin.version>
         <jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
         <mtf.tools.version>1.1.2</mtf.tools.version>
+        <!-- JDK 17 Compatibility Props -->
+        <mule.sdk.api.version>0.10.1</mule.sdk.api.version>
     </properties>
 
     <dependencies>
@@ -56,6 +58,11 @@
             <groupId>org.mule.connectors</groupId>
             <artifactId>mule-db-client</artifactId>
             <version>${muleDbClientVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.sdk</groupId>
+            <artifactId>mule-sdk-api</artifactId>
+            <version>${mule.sdk.api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.mchange</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.teradata.mulesoft</groupId>
     <artifactId>mule4-teradata-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>Teradata Connector - Mule 4</name>
     <description>An extension that provides functionality for connecting any Mule project to Teradata Vantage</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
-        <munit.extensions.maven.plugin.version>1.1.1</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.4.0</munit.extensions.maven.plugin.version>
         <munit.version>2.3.6</munit.version>
 
         <mtf-tools.version>1.1.2</mtf-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <mule.sdk.api.version>0.10.1</mule.sdk.api.version>
         <jacoco.version>0.8.10</jacoco.version>
         <munit.extensions.maven.plugin.version>1.4.0</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.6</munit.version>
+        <munit.version>3.3.2</munit.version>
         <mtf.tools.version>1.1.2</mtf.tools.version>
         <mule.maven.plugin.version>3.8.1</mule.maven.plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <xmlunit.version>1.6</xmlunit.version>
         <javax.transaction.version>1.3</javax.transaction.version>
         <xaPoolVersion>1.5.0</xaPoolVersion>
-        <cglibVersion>3.3.0</cglibVersion>
+        <net.bytebuddy.version>1.14.5</net.bytebuddy.version>
         <muleDbClientVersion>1.6.0</muleDbClientVersion>
         <muleExtensionsShadeVersion>1.0.4</muleExtensionsShadeVersion>
 
@@ -47,10 +47,10 @@
         <skipTita>false</skipTita>
         <settingsFile>${java.io.tmpdir}/effective-settings.xml</settingsFile>
         <mule.maven.plugin.version>3.8.1</mule.maven.plugin.version>
-        <jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
         <mtf.tools.version>1.1.2</mtf.tools.version>
         <!-- JDK 17 Compatibility Props -->
         <mule.sdk.api.version>0.10.1</mule.sdk.api.version>
+        <jacoco.version>0.8.10</jacoco.version>
     </properties>
 
     <dependencies>
@@ -101,9 +101,9 @@
             <version>${caffeineVersion}</version>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>${cglibVersion}</version>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${net.bytebuddy.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -283,7 +283,7 @@
                     <argLines>
                         <!--suppress UnresolvedMavenProperty -->
                         <argLine>
-                            -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.maven.plugin.version}/org.jacoco.agent-${jacoco.maven.plugin.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec
+                            -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec
                         </argLine>
                     </argLines>
                     <runtimeConfiguration>
@@ -333,7 +333,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.maven.plugin.version}</version>
+                <version>${jacoco.version}</version>
                 <configuration>
                     <skip>false</skip>
                     <output>file</output>

--- a/pom.xml
+++ b/pom.xml
@@ -364,5 +364,18 @@
             <name>Nexus Public Releases</name>
             <url>https://repository-master.mulesoft.org/nexus/content/repositories/releases/</url>
         </repository>
+        <repository>
+            <id>mule</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>mule-plugin</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,17 +40,15 @@
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
-        <munit.extensions.maven.plugin.version>1.4.0</munit.extensions.maven.plugin.version>
-        <munit.version>2.3.6</munit.version>
-
-        <mtf-tools.version>1.1.2</mtf-tools.version>
         <skipTita>false</skipTita>
         <settingsFile>${java.io.tmpdir}/effective-settings.xml</settingsFile>
-        <mule.maven.plugin.version>3.8.1</mule.maven.plugin.version>
-        <mtf.tools.version>1.1.2</mtf.tools.version>
         <!-- JDK 17 Compatibility Props -->
         <mule.sdk.api.version>0.10.1</mule.sdk.api.version>
         <jacoco.version>0.8.10</jacoco.version>
+        <munit.extensions.maven.plugin.version>1.4.0</munit.extensions.maven.plugin.version>
+        <munit.version>2.3.6</munit.version>
+        <mtf.tools.version>1.1.2</mtf.tools.version>
+        <mule.maven.plugin.version>3.8.1</mule.maven.plugin.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/mule/extension/db/internal/DbConnector.java
+++ b/src/main/java/org/mule/extension/db/internal/DbConnector.java
@@ -31,6 +31,11 @@ import org.mule.runtime.extension.api.annotation.Sources;
 import org.mule.runtime.extension.api.annotation.connectivity.ConnectionProviders;
 import org.mule.runtime.extension.api.annotation.dsl.xml.Xml;
 import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
+import org.mule.sdk.api.annotation.JavaVersionSupport;
+
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_11;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_17;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_8;
 
 /**
  * The Anypoint Database Connector allows you to connect to relational databases through the JDBC API.
@@ -48,6 +53,7 @@ import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
 @Export(
     classes = {QueryDefinition.class, StoredProcedureCall.class, BulkQueryDefinition.class, ConnectionCreationException.class,
         LoggerApiPackage.class})
+@JavaVersionSupport({JAVA_8, JAVA_11, JAVA_17})
 public class DbConnector extends AbstractDbConnector {
 
 }


### PR DESCRIPTION
The current connector version(1.0.0) is compatible with Java 8 and 11 but not with Java 17.

**Major changes:** These are the two changes needed in any mule project to make the connector compatible with Java 17

1. To communicate Java 17 compatibility, generate metadata for Java compatibility of your custom connector by adding or upgrading the custom connector mule-sdk-api dependency to the latest version
The following dependency should be added to the pom.xml file:
```
<dependency>
   <groupId>org.mule.sdk</groupId>
   <artifactId>mule-sdk-api</artifactId>
   <version>0.10.1</version>
</dependency> 
```
2. For Java SDK, add the @JavaVersionSupport annotation in the same class as the @Extension annotation and include the JAVA_17 value, for example:
```
@Extension(name = "Database")
@Operations(...)
@JavaVersionSupport({JAVA_8, JAVA_11, JAVA_17})
public class DbConnector {
..
}
```
**Additional changes for Java 17 compatible properties:**

1. Library Updates: 
Replace CGLib with ByteBuddy. Upgrade ByteBuddy to version 1.14.0.
Upgrade Jacoco to version 0.8.10.

2. MUNIT Plugin Upgrades:
Upgrade MUnit Maven Plugin to 3.3.2 and munit.extensions.maven.plugin.version to 1.4.0.
The upgradation versions of above MUNIT plugins is in sync with mule-db-connector main repository branch.
There is a compatibility matrix between Maven, Mule Maven Plugin, and MUnit Maven Plugin that must be followed to avoid dependency conflicts and ensure smooth operation.

Compatibility Matrix

- Maven 3.9.x (e.g., 3.9.6):
Mule Maven Plugin: 3.8.1
MUnit Maven Plugin: 3.3.2 (Recommended)

- Maven 3.8.8:
Mule Maven Plugin: 4.1.2
MUnit Maven Plugin: 2.3.18 (Alternative)

Since Maven 3.9.6 is in use, the first combination (Mule Maven Plugin 3.8.1 and MUnit Maven Plugin 3.3.2) was chosen to align dependencies and prevent runtime conflicts.
Older plugin versions (e.g., MUnit Maven Plugin 2.3.6) caused runtime errors, such as NoSuchMethodError, due to outdated dependencies (e.g., org.eclipse.aether) that were incompatible with Maven 3.9.6. Upgrading to the recommended plugin versions ensures dependency alignment and resolves these conflicts.

**Features:**

1. Run Mule Flows with Java 17: The connector now supports running Mule flows using Java 17.
2. Stable Version: Java 17 is a stable version that includes more security and enhancements.
3. Updated Libraries: Leverage updated libraries and APIs available in Java 17 for better functionality and performance.

**Referrences:**
https://docs.mulesoft.com/mule-sdk/latest/partner-connector-upgrade